### PR TITLE
Remove the dependency on ros2_console

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,6 @@ find_package(rclcpp REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
-find_package(ros2_console REQUIRED)
 
 find_package(Boost REQUIRED COMPONENTS system thread)
 
@@ -22,30 +21,30 @@ find_package(Eigen REQUIRED)
 
 ament_python_install_package(${PROJECT_NAME})
 
-set(INCLUDE_DIRS include ${ament_cmake_INCLUDE_DIRS} ${angles_INCLUDE_DIRS}
-  ${cmake_modules_INCLUDE_DIRS} ${rclcpp_INCLUDE_DIRS} ${sensor_msgs_INCLUDE_DIRS}
-  ${tf2_INCLUDE_DIRS} ${tf2_ros_INCLUDE_DIRS} ${ros2_console_INCLUDE_DIRS}
-  ${Boost_INCLUDE_DIRS} ${Eigen_INCLUDE_DIRS})
-include_directories(${INCLUDE_DIRS})
-
-set(LIBRARY_DIRS ${ament_cmake_LIBRARY_DIRS} ${angles_LIBRARY_DIRS}
-  ${cmake_modules_LIBRARY_DIRS} ${rclcpp_LIBRARY_DIRS} ${sensor_msgs_LIBRARY_DIRS}
-  ${tf2_LIBRARY_DIRS} ${tf2_ros_LIBRARY_DIRS} ${ros2_console_LIBRARY_DIRS}
-  ${Boost_LIBRARY_DIRS} ${Eigen_LIBRARY_DIRS})
-
-link_directories(${LIBRARY_DIRS})
-
-set(LIBS ${ament_cmake_LIBRARIES} ${angles_LIBRARIES} ${cmake_modules_LIBRARIES}
-  ${rclcpp_LIBRARIES} ${sensor_msgs_LIBRARIES} ${tf2_LIBRARIES} ${tf2_ros_LIBRARIES}
-  ${ros2_console_LIBRARIES} ${Boost_LIBRARIES} ${Eigen_LIBRARIES})
+include_directories(include)
 
 add_library(laser_geometry SHARED src/laser_geometry.cpp)
-target_link_libraries(laser_geometry ${LIBS})
+
+ament_target_dependencies(laser_geometry
+  "rclcpp"
+  "sensor_msgs"
+  "tf2"
+  "tf2_ros")
+
+target_include_directories(laser_geometry
+  PUBLIC ${angles_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${Eigen_INCLUDE_DIRS}
+)
+
+target_link_libraries(laser_geometry
+  ${angles_LIBRARIES}
+  ${Boost_LIBRARIES}
+  ${Eigen_LIBRARIES}
+)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
-  
+
   #ament_add_gtest(projection_test test/projection_test.cpp)
   #target_link_libraries(projection_test laser_geometry ${LIBS})
 
@@ -69,8 +68,6 @@ ament_export_dependencies(rclcpp)
 ament_export_dependencies(sensor_msgs)
 ament_export_dependencies(tf2)
 ament_export_dependencies(tf2_ros)
-ament_export_dependencies(ros2_console)
-ament_export_include_directories(${INCLUDE_DIRS})
-ament_export_libraries(laser_geometry ${LIBS})
+ament_export_libraries(laser_geometry)
 
 ament_package()

--- a/package.xml
+++ b/package.xml
@@ -28,7 +28,6 @@
   <build_depend>sensor_msgs</build_depend>
   <build_depend>tf2</build_depend>
   <build_depend>tf2_ros</build_depend>
-  <build_depend>ros2_console</build_depend>
 
   <exec_depend>angles</exec_depend>
   <exec_depend>boost</exec_depend>
@@ -38,7 +37,6 @@
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>tf2</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
-  <exec_depend>ros2_console</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>

--- a/src/laser_geometry.cpp
+++ b/src/laser_geometry.cpp
@@ -26,14 +26,17 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#include "laser_geometry/laser_geometry.h"
 #include <algorithm>
-#include <ros2_console/assert.hpp>
-#include <ros2_console/console.hpp>
-#include <tf2_ros/buffer_interface.h>
-#include <tf2/LinearMath/Transform.h>
-#include <tf2/LinearMath/Scalar.h>
+#include <assert.h>
 
+#include "laser_geometry/laser_geometry.h"
+#include "rcutils/logging_macros.h"
+
+#include "tf2_ros/buffer.h"
+#include "tf2/LinearMath/Transform.h"
+#include "tf2/LinearMath/Quaternion.h"
+#include "tf2/utils.h"
+#include "tf2/transform_datatypes.h"
 
 namespace laser_geometry
 {
@@ -119,7 +122,7 @@ namespace laser_geometry
         //double x = cloud_out.points[count].x;
         //double y = cloud_out.points[count].y;
         //if(x*x + y*y < scan_in.range_min * scan_in.range_min){
-        //  ROS_INFO("(%.2f, %.2f)", cloud_out.points[count].x, cloud_out.points[count].y);
+        //  RCUTILS_LOG_INFO("(%.2f, %.2f)", cloud_out.points[count].x, cloud_out.points[count].y);
         //}
 
         // Save the original point index
@@ -252,7 +255,7 @@ const boost::numeric::ublas::matrix<double>& LaserProjection::getUnitVectors_(do
     }
 
     //check just in case
-    ROS_ASSERT(index_channel_idx >= 0);
+    assert(index_channel_idx >= 0);
 
     for(unsigned int i = 0; i < cloud_out.points.size(); ++i)
     {
@@ -311,7 +314,7 @@ const boost::numeric::ublas::matrix<double>& LaserProjection::getUnitVectors_(do
     // Check if our existing co_sine_map is valid
     if (co_sine_map_.rows () != (int)n_pts || angle_min_ != scan_in.angle_min || angle_max_ != scan_in.angle_max )
     {
-      ROS_DEBUG ("[projectLaser] No precomputed map given. Computing one.");
+      RCUTILS_LOG_DEBUG ("[projectLaser] No precomputed map given. Computing one.");
       co_sine_map_ = Eigen::ArrayXXd (n_pts, 2);
       angle_min_ = scan_in.angle_min;
       angle_max_ = scan_in.angle_max;


### PR DESCRIPTION
Remove the dependency on ros2_console
Fixed ament build error: fail to find ros2,ros2_tf include headers

Signed-off-by: Gu, Chao Jie <chao.jie.gu@intel.com>