### PR TITLE
Remove the dependency on boost::mutex::scoped_lock

### DIFF
--- a/include/laser_geometry/laser_geometry.h
+++ b/include/laser_geometry/laser_geometry.h
@@ -33,9 +33,9 @@
 #include <map>
 #include <iostream>
 #include <sstream>
+#include <mutex>
 
 #include "boost/numeric/ublas/matrix.hpp"
-#include "boost/thread/mutex.hpp"
 
 #include <tf2/buffer_core.h>
 
@@ -305,7 +305,7 @@ namespace laser_geometry
       float angle_min_;
       float angle_max_;
       Eigen::ArrayXXd co_sine_map_;
-      boost::mutex guv_mutex_;
+      std::mutex guv_mutex_;
     };
 
 }

--- a/src/laser_geometry.cpp
+++ b/src/laser_geometry.cpp
@@ -156,7 +156,7 @@ namespace laser_geometry
 
 const boost::numeric::ublas::matrix<double>& LaserProjection::getUnitVectors_(double angle_min, double angle_max, double angle_increment, unsigned int length)
   {
-    boost::mutex::scoped_lock guv_lock(this->guv_mutex_);
+    std::unique_lock<std::mutex>  guv_lock(this->guv_mutex_);
 
     //construct string for lookup in the map
     std::stringstream anglestring;


### PR DESCRIPTION
A unique lock is an object that manages a mutex object with unique ownership in both states: locked and unlocked which can replace the boost::mutex::scoped_lock completely.