### PR TITLE
Remove Boost boost::numeric::ublas::matrix dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,9 +15,7 @@ find_package(sensor_msgs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
 
-find_package(Boost REQUIRED COMPONENTS system thread)
-
-find_package(Eigen REQUIRED)
+find_package(Eigen3 REQUIRED)
 
 ament_python_install_package(${PROJECT_NAME})
 
@@ -32,13 +30,11 @@ ament_target_dependencies(laser_geometry
   "tf2_ros")
 
 target_include_directories(laser_geometry
-  PUBLIC ${angles_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${Eigen_INCLUDE_DIRS}
+  PUBLIC ${angles_INCLUDE_DIRS} ${EIGEN3_INCLUDE_DIRS}
 )
 
 target_link_libraries(laser_geometry
   ${angles_LIBRARIES}
-  ${Boost_LIBRARIES}
-  ${Eigen_LIBRARIES}
 )
 
 if(BUILD_TESTING)

--- a/include/laser_geometry/laser_geometry.h
+++ b/include/laser_geometry/laser_geometry.h
@@ -34,8 +34,8 @@
 #include <iostream>
 #include <sstream>
 #include <mutex>
-
-#include "boost/numeric/ublas/matrix.hpp"
+#include <Eigen/Core>
+#include <Eigen/Dense>
 
 #include <tf2/buffer_core.h>
 
@@ -43,7 +43,6 @@
 #include "sensor_msgs/msg/point_cloud.hpp"
 #include "sensor_msgs/msg/point_cloud.hpp"
 
-#include <Eigen/Core>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 
 namespace laser_geometry
@@ -253,7 +252,7 @@ namespace laser_geometry
        * it is left protected so that test code can evaluate it
        * appropriately.
        */
-      const boost::numeric::ublas::matrix<double>& getUnitVectors_(double angle_min,
+      const Eigen::MatrixXd& getUnitVectors_(double angle_min,
                                                                    double angle_max,
                                                                    double angle_increment,
                                                                    unsigned int length);
@@ -301,7 +300,7 @@ namespace laser_geometry
                                             int channel_options);
 
       //! Internal map of pointers to stored values
-      std::map<std::string,boost::numeric::ublas::matrix<double>* > unit_vector_map_;
+      std::map<std::string, Eigen::MatrixXd* > unit_vector_map_;
       float angle_min_;
       float angle_max_;
       Eigen::ArrayXXd co_sine_map_;

--- a/package.xml
+++ b/package.xml
@@ -21,7 +21,6 @@
   <buildtool_depend>ament_python_cmake</buildtool_depend>
 
   <build_depend>angles</build_depend>
-  <build_depend>boost</build_depend>
   <build_depend>cmake_modules</build_depend>
   <build_depend>eigen</build_depend>
   <build_depend>rclcpp</build_depend>
@@ -30,7 +29,6 @@
   <build_depend>tf2_ros</build_depend>
 
   <exec_depend>angles</exec_depend>
-  <exec_depend>boost</exec_depend>
   <exec_depend>eigen</exec_depend>
   <exec_depend>python-numpy</exec_depend>
   <exec_depend>rclcpp</exec_depend>

--- a/test/projection_test.cpp
+++ b/test/projection_test.cpp
@@ -77,7 +77,7 @@ sensor_msgs::msg::LaserScan build_constant_scan(double range, double intensity,
 class TestProjection : public laser_geometry::LaserProjection
 {
 public:
-  const boost::numeric::ublas::matrix<double>& getUnitVectors(double angle_min,
+  const Eigen::MatrixXd& getUnitVectors(double angle_min,
                                                               double angle_max,
                                                               double angle_increment,
                                                               unsigned int length)
@@ -91,7 +91,7 @@ void test_getUnitVectors(double angle_min, double angle_max, double angle_increm
   double tolerance = 1e-12;
   TestProjection projector;  
   
-  const boost::numeric::ublas::matrix<double> & mat = projector.getUnitVectors(angle_min, angle_max, angle_increment, length);
+  const Eigen::MatrixXd & mat = projector.getUnitVectors(angle_min, angle_max, angle_increment, length);
   
   
 


### PR DESCRIPTION
According to the Migration guideline, avoiding the dependency on boost where possible. Due to changing the member function in laser_geometry.h, so this patch will impact packages which depend on laser_geometry.